### PR TITLE
Add newline at EOF for Chicago pizza headers

### DIFF
--- a/examples/factory_method/chicago_pizza_bacon.hpp
+++ b/examples/factory_method/chicago_pizza_bacon.hpp
@@ -1,9 +1,9 @@
 #pragma once
-#include "pizza.hpp"
 #include "ingredient_creators/ingredient_creators.hpp"
+#include "pizza.hpp"
 #include <memory>
-#include <vector>
 #include <utility>
+#include <vector>
 
 inline auto create_chicago_bacon_pizza() -> std::unique_ptr<Pizza> {
     ThickCrustDoughCreator dough_creator;

--- a/examples/factory_method/chicago_pizza_cheese.hpp
+++ b/examples/factory_method/chicago_pizza_cheese.hpp
@@ -1,9 +1,9 @@
 #pragma once
-#include "pizza.hpp"
 #include "ingredient_creators/ingredient_creators.hpp"
+#include "pizza.hpp"
 #include <memory>
-#include <vector>
 #include <utility>
+#include <vector>
 
 inline auto create_chicago_cheese_pizza() -> std::unique_ptr<Pizza> {
     ThickCrustDoughCreator dough_creator;

--- a/examples/factory_method/chicago_pizza_pepperoni.hpp
+++ b/examples/factory_method/chicago_pizza_pepperoni.hpp
@@ -1,9 +1,9 @@
 #pragma once
-#include "pizza.hpp"
 #include "ingredient_creators/ingredient_creators.hpp"
+#include "pizza.hpp"
 #include <memory>
-#include <vector>
 #include <utility>
+#include <vector>
 
 inline auto create_chicago_pepperoni_pizza() -> std::unique_ptr<Pizza> {
     ThickCrustDoughCreator dough_creator;

--- a/examples/factory_method/chicago_pizza_pineapple.hpp
+++ b/examples/factory_method/chicago_pizza_pineapple.hpp
@@ -1,9 +1,9 @@
 #pragma once
-#include "pizza.hpp"
 #include "ingredient_creators/ingredient_creators.hpp"
+#include "pizza.hpp"
 #include <memory>
-#include <vector>
 #include <utility>
+#include <vector>
 
 inline auto create_chicago_pineapple_pizza() -> std::unique_ptr<Pizza> {
     ThickCrustDoughCreator dough_creator;

--- a/examples/factory_method/chicago_pizza_store.hpp
+++ b/examples/factory_method/chicago_pizza_store.hpp
@@ -1,28 +1,30 @@
 #pragma once
 
-#include "pizza.hpp"
-#include "factory/dynamic_factory.hpp"
-#include "chicago_pizza_cheese.hpp"
 #include "chicago_pizza_bacon.hpp"
+#include "chicago_pizza_cheese.hpp"
 #include "chicago_pizza_pepperoni.hpp"
 #include "chicago_pizza_pineapple.hpp"
 #include "chicago_pizza_veggie.hpp"
+#include "factory/dynamic_factory.hpp"
+#include "pizza.hpp"
 
 class ChicagoPizzaStore {
-public:
+  public:
     ChicagoPizzaStore() {
         pizza_factory_.register_creator("cheese", &create_chicago_cheese_pizza);
         pizza_factory_.register_creator("bacon", &create_chicago_bacon_pizza);
-        pizza_factory_.register_creator("pepperoni", &create_chicago_pepperoni_pizza);
-        pizza_factory_.register_creator("pineapple", &create_chicago_pineapple_pizza);
+        pizza_factory_.register_creator("pepperoni",
+                                        &create_chicago_pepperoni_pizza);
+        pizza_factory_.register_creator("pineapple",
+                                        &create_chicago_pineapple_pizza);
         pizza_factory_.register_creator("veggie", &create_chicago_veggie_pizza);
     }
 
     [[nodiscard]]
-    std::unique_ptr<Pizza> order(const std::string& type) const {
+    std::unique_ptr<Pizza> order(const std::string &type) const {
         return pizza_factory_.make(type);
     }
 
-private:
+  private:
     Dynamic_factory<Pizza, std::string> pizza_factory_;
 };

--- a/examples/factory_method/chicago_pizza_veggie.hpp
+++ b/examples/factory_method/chicago_pizza_veggie.hpp
@@ -1,9 +1,9 @@
 #pragma once
-#include "pizza.hpp"
 #include "ingredient_creators/ingredient_creators.hpp"
+#include "pizza.hpp"
 #include <memory>
-#include <vector>
 #include <utility>
+#include <vector>
 
 inline auto create_chicago_veggie_pizza() -> std::unique_ptr<Pizza> {
     ThickCrustDoughCreator dough_creator;


### PR DESCRIPTION
## Summary
- enforce trailing newline in all Chicago pizza headers
- apply clang-format to updated files

## Testing
- `cmake -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_683ffda90dc0832cb82b912a903009f6