### PR TITLE
Add dynamic factory unregister unit test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 add_executable(pizza_tests
     test_abstract_factory.cpp
     test_factory_method.cpp
+    test_dynamic_factory.cpp
 )
 
 target_include_directories(pizza_tests PRIVATE

--- a/tests/test_dynamic_factory.cpp
+++ b/tests/test_dynamic_factory.cpp
@@ -1,0 +1,15 @@
+#include <gtest/gtest.h>
+#include <factory/dynamic_factory.hpp>
+#include "pizza.hpp"
+#include "ny_pizza_cheese.hpp"
+
+TEST(DynamicFactoryTest, RegisterAndUnregister) {
+    Dynamic_factory<Pizza, std::string> factory;
+    EXPECT_TRUE(factory.is_empty());
+
+    factory.register_creator("cheese", &create_ny_cheese_pizza);
+    EXPECT_FALSE(factory.is_empty());
+
+    EXPECT_TRUE(factory.unregister_creator("cheese"));
+    EXPECT_TRUE(factory.is_empty());
+}


### PR DESCRIPTION
## Summary
- add test_dynamic_factory.cpp verifying Dynamic_factory register/unregister
- compile new test in tests/CMakeLists.txt

## Testing
- `cmake -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_683ffd9d84e8832c9b53cbabf0ee5016